### PR TITLE
Titan/Cassandra export

### DIFF
--- a/src/main/java/com/thinkaurelius/faunus/FaunusGraph.java
+++ b/src/main/java/com/thinkaurelius/faunus/FaunusGraph.java
@@ -90,7 +90,8 @@ public class FaunusGraph {
 
     public Path getOutputLocation() {
         if (null == this.configuration.get(OUTPUT_LOCATION))
-            return null;
+            throw new IllegalStateException("Please set " + OUTPUT_LOCATION + " configuration option.");
+
         return new Path(this.configuration.get(OUTPUT_LOCATION));
     }
 

--- a/src/main/java/com/thinkaurelius/faunus/formats/titan/cassandra/FaunusTitanCassandraGraph.java
+++ b/src/main/java/com/thinkaurelius/faunus/formats/titan/cassandra/FaunusTitanCassandraGraph.java
@@ -24,15 +24,15 @@ import java.util.SortedMap;
 
 public class FaunusTitanCassandraGraph extends StandardTitanGraph {
 
-    private final InternalTitanTransaction tx;
-
-    public FaunusTitanCassandraGraph(final String configFile) throws ConfigurationException {
-        this(new PropertiesConfiguration(configFile));
-    }
+    private final InternalTitanTransaction tx; /* it's only for reading a Titan graph into Hadoop. */
 
     public FaunusTitanCassandraGraph(final Configuration configuration) {
+        this(configuration, true);
+    }
+
+    public FaunusTitanCassandraGraph(final Configuration configuration, boolean autoTx) {
         super(new GraphDatabaseConfiguration(configuration));
-        this.tx = startTransaction(new TransactionConfig(this.getConfiguration()));
+        this.tx = (autoTx) ? startTransaction(new TransactionConfig(this.getConfiguration())) : null;
     }
 
     public FaunusVertex readFaunusVertex(final ByteBuffer key, final SortedMap<ByteBuffer, IColumn> value) {
@@ -43,7 +43,9 @@ public class FaunusTitanCassandraGraph extends StandardTitanGraph {
 
     @Override
     public void shutdown() {
-        tx.abort();
+        if (tx != null)
+            tx.abort();
+
         super.shutdown();
     }
 

--- a/src/main/java/com/thinkaurelius/faunus/formats/titan/cassandra/TitanCassandraOutputFormat.java
+++ b/src/main/java/com/thinkaurelius/faunus/formats/titan/cassandra/TitanCassandraOutputFormat.java
@@ -48,7 +48,7 @@ public class TitanCassandraOutputFormat extends OutputFormat<NullWritable, Faunu
         final BaseConfiguration titanconfig = new BaseConfiguration();
         //General Titan configuration for read-only
         //titanconfig.setProperty("storage.read-only", "true"); // TODO: Should we make this simply false?
-        titanconfig.setProperty("autotype", "none");
+        titanconfig.setProperty("autotype", "blueprints");
         //Cassandra specific configuration
         titanconfig.setProperty("storage.backend", "cassandra");   // todo: astyanax
         titanconfig.setProperty("storage.hostname", ConfigHelper.getOutputInitialAddress(config));
@@ -59,7 +59,7 @@ public class TitanCassandraOutputFormat extends OutputFormat<NullWritable, Faunu
         if (ConfigHelper.getWriteConsistencyLevel(config) != null)
             titanconfig.setProperty("storage.write-consistency-level", ConfigHelper.getWriteConsistencyLevel(config));
 
-        this.graph = new FaunusTitanCassandraGraph(titanconfig);
+        this.graph = new FaunusTitanCassandraGraph(titanconfig, false);
         //this.pathEnabled = config.getBoolean(FaunusCompiler.PATH_ENABLED, false);
         this.config = config;
     }

--- a/src/main/java/com/thinkaurelius/faunus/formats/titan/cassandra/TitanCassandraRecordWriter.java
+++ b/src/main/java/com/thinkaurelius/faunus/formats/titan/cassandra/TitanCassandraRecordWriter.java
@@ -1,6 +1,11 @@
 package com.thinkaurelius.faunus.formats.titan.cassandra;
 
 import com.thinkaurelius.faunus.FaunusVertex;
+import com.thinkaurelius.titan.core.TitanEdge;
+import com.thinkaurelius.titan.core.TitanTransaction;
+import com.thinkaurelius.titan.core.TitanVertex;
+import com.tinkerpop.blueprints.Direction;
+import com.tinkerpop.blueprints.Edge;
 import org.apache.cassandra.thrift.Mutation;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.RecordWriter;
@@ -8,7 +13,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
+import java.util.*;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -17,6 +22,9 @@ public class TitanCassandraRecordWriter extends RecordWriter<NullWritable, Faunu
 
     private final FaunusTitanCassandraGraph graph;
     private final RecordWriter<ByteBuffer, List<Mutation>> writer;
+
+    private final Map<Object, Long> vertexIds = new TreeMap<Object, Long>();
+    private final Set<Object> processedEdges  = new HashSet<Object>();
 
     public TitanCassandraRecordWriter(final FaunusTitanCassandraGraph graph, RecordWriter<ByteBuffer, List<Mutation>> writer) {
         this.graph = graph;
@@ -27,21 +35,55 @@ public class TitanCassandraRecordWriter extends RecordWriter<NullWritable, Faunu
         this.writer.close(context);
     }
 
-    public void write(final NullWritable key, final FaunusVertex value) throws InterruptedException, IOException {
+    public void write(final NullWritable key, final FaunusVertex vertex) throws InterruptedException, IOException {
+        TitanTransaction tx = graph.startTransaction();
 
-        /*Mutation mut = new Mutation();
-        Column c = new Column();
-        c.setName(ByteBuffer.wrap(("col1").getBytes("UTF-8")));
-        c.setValue(ByteBuffer.allocate(8).putLong(value.getIdAsLong()).array());
-        c.setTimestamp(System.currentTimeMillis());
-        ColumnOrSuperColumn t = new ColumnOrSuperColumn();
-        t.setColumn(c);
-        mut.setColumn_or_supercolumn(t);
+        try {
+            processVertex(vertex, tx);
+        } catch (RuntimeException e) {
+            tx.abort();
+            throw e;
+        } finally {
+            tx.commit();
+        }
+    }
 
-        this.writer.write(ByteBuffer.wrap(("myval").getBytes("UTF-8")), Arrays.asList(mut));*/
+    private void processVertex(FaunusVertex vertex, TitanTransaction tx) {
+        TitanVertex v = createOrGetTitanVertex(tx, vertex.getId());
 
-        // TODO:
-        //   - Note that if the keyspace doesn't exist, it is created (not so for HBase and table)
+        for (Map.Entry<String, Object> prop : vertex.getProperties().entrySet()) {
+            tx.addProperty(v, prop.getKey(), prop.getValue());
+        }
 
+        storeEdges(vertex.getEdges(Direction.BOTH), tx);
+    }
+
+    private TitanVertex createOrGetTitanVertex(TitanTransaction tx, Object vertexId) {
+        Long titanId = vertexIds.get(vertexId);
+
+        if (titanId != null)
+            return tx.getVertex(titanId.longValue());
+
+        TitanVertex v = tx.addVertex();
+        assert v != null : "Failed to create new Titan Vertex for Faunus ID: " + vertexId + ".";
+
+        vertexIds.put(vertexId, v.getID());
+
+        return v;
+    }
+
+    private void storeEdges(Iterable<Edge> edges, TitanTransaction tx) {
+        for (Edge e : edges) {
+            if (processedEdges.contains(e.getId())) // this edge has already been created
+                continue;
+
+            // make sure that vertices are allocated in Titan (properties are going to be added on 'processVertex' phrase)
+            TitanVertex out = createOrGetTitanVertex(tx, e.getVertex(Direction.OUT).getId());
+            TitanVertex in  = createOrGetTitanVertex(tx, e.getVertex(Direction.IN).getId());
+
+            TitanEdge tEdge = tx.addEdge(out, in, e.getLabel());
+            assert tEdge != null : "Failed to create new Titan Edge for Faunus Edge: " + e;
+            processedEdges.add(e.getId());
+        }
     }
 }


### PR DESCRIPTION
Titan/Cassandra export with one limitation - no indexes, transaction is made per vertex so it keeps minimum amount of data in the memory (on Titan side).
