### PR TITLE
Fixed compilation error caused by Titan commit 639d431.

### DIFF
--- a/src/main/java/com/thinkaurelius/faunus/formats/titan/FaunusTitanGraph.java
+++ b/src/main/java/com/thinkaurelius/faunus/formats/titan/FaunusTitanGraph.java
@@ -6,7 +6,7 @@ import com.thinkaurelius.titan.diskstorage.util.StaticByteBuffer;
 import com.thinkaurelius.titan.graphdb.configuration.GraphDatabaseConfiguration;
 import com.thinkaurelius.titan.graphdb.database.StandardTitanGraph;
 import com.thinkaurelius.titan.graphdb.transaction.StandardTitanTx;
-import com.thinkaurelius.titan.graphdb.transaction.TransactionConfig;
+import com.thinkaurelius.titan.graphdb.transaction.StandardTransactionBuilder;
 import org.apache.commons.configuration.Configuration;
 
 import java.nio.ByteBuffer;
@@ -28,7 +28,10 @@ public class FaunusTitanGraph extends StandardTitanGraph {
 
     public FaunusTitanGraph(final Configuration configuration, boolean autoTx) {
         super(new GraphDatabaseConfiguration(configuration));
-        this.tx = (autoTx) ? newTransaction(new TransactionConfig(this.getConfiguration(), false)) : null;
+
+        //Used to be TranscationConfig(this.getConfiguration, false) indicating that this is not threadBound
+        //which is the defaul for Transaction
+        this.tx = (autoTx) ? newTransaction(new StandardTransactionBuilder(this.getConfiguration(), this)) : null;
     }
 
     protected FaunusVertex readFaunusVertex(final ByteBuffer key, Iterable<Entry> entries) {


### PR DESCRIPTION
TranscationConfig was eliminated. The interface TransactionConfiguration
was  introducted, and an implemention of it StandardTransactionBuilder
was written.  This commit changes FaunusTitanGraph to use
StrandardTransactionBuilder.

I'm sure you guys are about to get to this. Figure i'd jump the gun. 
