### PR TITLE
GraphSONInputForrmat and GraphSONOutputFormat now support modes,

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
             <email>me@matthiasb.com</email>
             <url>http://matthiasb.com</url>
         </contributor>
+        <contributor>
+            <name>Robin Syihab</name>
+            <email>robin@digaku.com</email>
+            <url>http://robin.nosql.asia</url>
+        </contributor>
     </contributors>
     <inceptionYear>2012</inceptionYear>
     <licenses>

--- a/src/main/java/com/thinkaurelius/faunus/formats/graphson/GraphSONInputFormat.java
+++ b/src/main/java/com/thinkaurelius/faunus/formats/graphson/GraphSONInputFormat.java
@@ -2,6 +2,7 @@ package com.thinkaurelius.faunus.formats.graphson;
 
 import com.thinkaurelius.faunus.FaunusVertex;
 import com.thinkaurelius.faunus.formats.VertexQueryFilter;
+import com.tinkerpop.blueprints.util.io.graphson.GraphSONMode;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -25,7 +26,20 @@ public class GraphSONInputFormat extends FileInputFormat<NullWritable, FaunusVer
 
     @Override
     public RecordReader<NullWritable, FaunusVertex> createRecordReader(final InputSplit split, final TaskAttemptContext context) {
-        return new GraphSONRecordReader(this.vertexQuery);
+
+        final GraphSONMode mode;
+
+        String modeStr = context.getConfiguration().getRaw("faunus.graphson.mode");
+
+        if (modeStr.equals("normal")){
+            mode = GraphSONMode.NORMAL;
+        }else if (modeStr.equals("extended")){
+            mode = GraphSONMode.EXTENDED;
+        }else{
+            mode = GraphSONMode.COMPACT;
+        }
+
+        return new GraphSONRecordReader(this.vertexQuery, mode);
     }
 
     @Override

--- a/src/main/java/com/thinkaurelius/faunus/formats/graphson/GraphSONOutputFormat.java
+++ b/src/main/java/com/thinkaurelius/faunus/formats/graphson/GraphSONOutputFormat.java
@@ -22,9 +22,9 @@ public class GraphSONOutputFormat extends FaunusFileOutputFormat {
 
         String modeStr = job.getConfiguration().getRaw("faunus.graphson.mode");
 
-        if (modeStr == "normal"){
+        if (modeStr.equals("normal")){
             mode = GraphSONMode.NORMAL;
-        }else if (modeStr == "extended"){
+        }else if (modeStr.equals("extended")){
             mode = GraphSONMode.EXTENDED;
         }else{
             mode = GraphSONMode.COMPACT;

--- a/src/main/java/com/thinkaurelius/faunus/formats/graphson/GraphSONRecordReader.java
+++ b/src/main/java/com/thinkaurelius/faunus/formats/graphson/GraphSONRecordReader.java
@@ -4,6 +4,7 @@ package com.thinkaurelius.faunus.formats.graphson;
 import com.thinkaurelius.faunus.FaunusVertex;
 import com.thinkaurelius.faunus.formats.VertexQueryFilter;
 import com.thinkaurelius.faunus.mapreduce.FaunusCompiler;
+import com.tinkerpop.blueprints.util.io.graphson.GraphSONMode;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
@@ -21,10 +22,16 @@ public class GraphSONRecordReader extends RecordReader<NullWritable, FaunusVerte
     private final LineRecordReader lineRecordReader;
     private final VertexQueryFilter vertexQuery;
     private FaunusVertex vertex = null;
+    private GraphSONMode mode;
 
     public GraphSONRecordReader(VertexQueryFilter vertexQuery) {
+        this(vertexQuery, GraphSONMode.COMPACT);
+    }
+
+    public GraphSONRecordReader(VertexQueryFilter vertexQuery, GraphSONMode mode) {
         this.lineRecordReader = new LineRecordReader();
         this.vertexQuery = vertexQuery;
+        this.mode = mode;
     }
 
     @Override
@@ -38,7 +45,8 @@ public class GraphSONRecordReader extends RecordReader<NullWritable, FaunusVerte
         if (!this.lineRecordReader.nextKeyValue())
             return false;
 
-        this.vertex = FaunusGraphSONUtility.fromJSON(this.lineRecordReader.getCurrentValue().toString());
+        this.vertex = FaunusGraphSONUtility.fromJSON(this.lineRecordReader.getCurrentValue().toString(), mode);
+
         this.vertexQuery.defaultFilter(this.vertex);
         this.vertex.enablePath(this.pathEnabled);
         return true;

--- a/src/main/java/com/thinkaurelius/faunus/formats/graphson/GraphSONRecordWriter.java
+++ b/src/main/java/com/thinkaurelius/faunus/formats/graphson/GraphSONRecordWriter.java
@@ -16,8 +16,8 @@ import java.io.UnsupportedEncodingException;
  * @author Stephen Mallette (http://stephen.genoprime.com)
  */
 public class GraphSONRecordWriter extends RecordWriter<NullWritable, FaunusVertex> {
-    private static final String UTF8 = "UTF-8";
-    private static final byte[] NEWLINE;
+    protected static final String UTF8 = "UTF-8";
+    protected static final byte[] NEWLINE;
     protected DataOutputStream out;
 
     static {


### PR DESCRIPTION
configurable via "faunus.graphson.mode"

Tested and worked for upgrading data from Titan 0.3.x to 0.4.x
using GraphSON extended via Faunus 0.3.x to generate output using "g._()"
and use Faunus 0.4.x to process the graphson generated by 0.3.x as the input.
